### PR TITLE
Migrating repo from dep to go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: go
 sudo: false
 go:
-- 1.11.x
+  - 1.12.x
 services:
   - docker
 install:
   - chmod 777 -R "$(pwd)"
-  - make dep
 script:
+  - travis_retry make dep
   - make lint
   - make test
   - make integration

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,0 @@
-# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
-# for detailed Gopkg.toml documentation.
-
-[prune]
-  go-tests = true
-  unused-packages = true

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,34 @@
 TAG := $(shell git rev-parse --short HEAD)
 DIR := $(shell pwd -L)
-GOPATH := ${GOPATH}
-ifeq ($(GOPATH),)
-	GOPATH := ${HOME}/go
-endif
-PROJECT_PATH := $(subst $(GOPATH)/src/,,$(DIR))
 
 dep:
 	docker run -ti \
-        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
-        -w "/go/src/$(PROJECT_PATH)" \
+        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -w "$(DIR)" \
         asecurityteam/sdcli:v1 go dep
 
 lint:
 	docker run -ti \
-        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
-        -w "/go/src/$(PROJECT_PATH)" \
+        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -w "$(DIR)" \
         asecurityteam/sdcli:v1 go lint
 
 test:
 	docker run -ti \
-        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
-        -w "/go/src/$(PROJECT_PATH)" \
+        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -w "$(DIR)" \
         asecurityteam/sdcli:v1 go test
 
 integration:
 	docker run -ti \
-        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
-        -w "/go/src/$(PROJECT_PATH)" \
+        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -w "$(DIR)" \
         asecurityteam/sdcli:v1 go integration
 
 coverage:
 	docker run -ti \
-        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
-        -w "/go/src/$(PROJECT_PATH)" \
+        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -w "$(DIR)" \
         asecurityteam/sdcli:v1 go coverage
 
 doc: ;

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/asecurityteam/rolling
+
+go 1.12


### PR DESCRIPTION
This PR implements go modules as the dependency system for this repository. Functionally, these changes should be mostly invisible. We will still have vendor directories in the top level of our repositories, and we will still be able to install dependencies via “sdcli go dep”. Also, you won’t need to worry about your code being on the GOPATH anymore.

travis.yml - I’ve moved “make dep” into the script, as our old method would not fail a build if the dep step failed (since the install step doesn’t seem to care about exit codes). I’ve also added the “travis_retry” function to make dep, so in case we fail to pull in a dependency due to network issues, we will simply rerun make dep. This will retry 2 more times before failing the build.

Gopkg.lock, Gopkg.toml - Deleted these files since they are no longer necessary

Makefile - I’ve removed all use of the Go path (/go/src/) in our volume binding for our SDCLI docker containers, since we should no longer need to worry about that. This is an entirely cosmetic change, and if for any reason anyone would prefer to keep the old /go/src/ + pwd approach, I can revert this change.

go.mod - This is the go mod equivalent of Gopkg.toml. One cool thing about go.mod is that dependencies will be updated here automatically. For instance, if you add a new import to main_test.go, and then run your unit tests, Go will automatically add the new dependency to go.mod. This is a pretty good resource on the topic: https://blog.golang.org/using-go-modules

go.sum - This is the go mod equivalent of Gopkg.lock. This is created/updated when you run “go mod vendor” or “go mod download” with go.mod file present.
