### PR TITLE
Added AppendWithTimestamp

### DIFF
--- a/time.go
+++ b/time.go
@@ -77,7 +77,6 @@ func (w *TimePolicy) AppendWithTimestamp(value float64, timestamp time.Time) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	//
 	var adjustedTime, windowOffset = w.selectBucket(timestamp)
 	w.keepConsistent(adjustedTime, windowOffset)
 	w.window[windowOffset] = append(w.window[windowOffset], value)

--- a/time.go
+++ b/time.go
@@ -72,16 +72,22 @@ func (w *TimePolicy) selectBucket(currentTime time.Time) (int64, int) {
 	return adjustedTime, windowOffset
 }
 
-// Append a value to the window using a time bucketing strategy.
-func (w *TimePolicy) Append(value float64) {
+// AppendWithTimestamp same as Append but with timestamp as parameter
+func (w *TimePolicy) AppendWithTimestamp(value float64, timestamp time.Time) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	var adjustedTime, windowOffset = w.selectBucket(time.Now())
+	//
+	var adjustedTime, windowOffset = w.selectBucket(timestamp)
 	w.keepConsistent(adjustedTime, windowOffset)
 	w.window[windowOffset] = append(w.window[windowOffset], value)
 	w.lastWindowTime = adjustedTime
 	w.lastWindowOffset = windowOffset
+}
+
+// Append a value to the window using a time bucketing strategy.
+func (w *TimePolicy) Append(value float64) {
+	w.AppendWithTimestamp(value, time.Now())
 }
 
 // Reduce the window to a single value using a reduction function.


### PR DESCRIPTION
We need to store Append with the timestamps received from network events rather than using system default `time.Now()`.